### PR TITLE
Add Trello link (README.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ How To Contribute
 =============
 Want to contribute to Go Everywhere? Great! All you have to do is fork our repository and edit it.  Then, submit a pull request. We will try to merge it into our repository, and if we are successful, it will be pushed to the site. It is that easy!
 
+Trello: https://trello.com/b/E6N7Zp6C/go-everywhere
+
 License
 =============
 Our code is licensed with the LGPL-2.1 open source license.


### PR DESCRIPTION
Add Trello link to README.md

This commit broke my link before.
